### PR TITLE
update 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure("2") do |config|
     SHELL
     
     config.vm.define "podman" do |podman|
-      podman.vm.box = "bento/ubuntu-20.10"
+      podman.vm.box = "bento/ubuntu-24.04"
       podman.vm.hostname = "podman"
       podman.vm.network "private_network", ip: "10.0.0.11"
       podman.vm.provider "virtualbox" do |vb|

--- a/nginx-image/Dockerfile
+++ b/nginx-image/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx:alpine
+FROM docker.io/nginx:alpine
 COPY index.html /usr/share/nginx/html/index.html


### PR DESCRIPTION
1. updated from Ubuntu 20.10 to 24.04.
2. updates the Dockerfile to use the fully qualified image name docker.io/nginx:alpine instead of the short name nginx:alpine. The change addresses a Podman compatibility issue where short names fail to resolve due to strict default registry policies. By explicitly specifying the Docker Hub registry, we ensure reliable image pulling across all Podman environments while maintaining security best practices.